### PR TITLE
Don't set cookies when viewing pages

### DIFF
--- a/Antispam/Antispam.hooks.php
+++ b/Antispam/Antispam.hooks.php
@@ -235,6 +235,12 @@ public static function onTitleMove( Title $title, Title $newtitle, User $user )
     {
         global $wgCTShowLink, $wgCTSFW, $wgCTAccessKey;
 
+        $context = $skin->getContext();
+        $action = Action::getActionName( $context );
+        if ( $action === 'view' ) {
+            return;
+        }
+
         $text .= CTBody::AddJSCode();
         CTBody::ctSetCookie();      
 

--- a/Antispam/Antispam.hooks.php
+++ b/Antispam/Antispam.hooks.php
@@ -10,7 +10,8 @@ class CTHooks {
      * @return none
      */
     public static function onUploadFilter ( $upload, $mime, &$error ) {
-        global $wgRequest, $wgCTExtName, $wgCTMinEditCount, $wgUser;
+        global $wgRequest, $wgCTExtName, $wgCTMinEditCount;
+        $user = RequestContext::getMain()->getUser();
         
         # Skip spam check if error exists already
         if ($error !== TRUE) {
@@ -20,12 +21,12 @@ class CTHooks {
         $allowUpload = true;
 
         // Skip antispam test if user is member of special group
-        if ( $wgUser->isAllowed('cleantalk-bypass') ) {
+        if ( $user->isAllowed('cleantalk-bypass') ) {
             return;
         }
 
         // Skip antispam test for user with getEditCount() more than setted value
-        $edit_count = $wgUser->getEditCount();
+        $edit_count = $user->getEditCount();
         if ( isset($edit_count) && $edit_count > $wgCTMinEditCount ) {
             return;
         }
@@ -34,8 +35,8 @@ class CTHooks {
         $ctResult = CTBody::onSpamCheck(
             'check_message', array(
                 'message' => $wgRequest->getVal('wpUploadDescription'),
-                'sender_email' => $wgUser->mEmail,
-                'sender_nickname' => $wgUser->mName,
+                'sender_email' => $user->mEmail,
+                'sender_nickname' => $user->mName,
             )
         );
         if ( $ctResult->errno != 0 ) {
@@ -73,7 +74,8 @@ class CTHooks {
      * @return bool
      */
     public static function onEditFilter (  $editor, $text, $section, &$error, $summary ) {
-        global $wgCTExtName, $wgCTNewEditsOnly, $wgCTMinEditCount, $wgUser;
+        global $wgCTExtName, $wgCTNewEditsOnly, $wgCTMinEditCount;
+        $user = $editor->getArticle()->getContext()->getUser();
         
         $allowEdit = true;
 
@@ -88,7 +90,7 @@ class CTHooks {
         }
 
         // Skip antispam test if user is member of special group
-        if ( $wgUser->isAllowed('cleantalk-bypass') ) {
+        if ( $user->isAllowed('cleantalk-bypass') ) {
             return $allowEdit;
         }
 
@@ -190,10 +192,10 @@ class CTHooks {
     }
 public static function onTitleMove( Title $title, Title $newtitle, User $user )
 {
-    global $wgUser, $wgCTExtName;
+    global $wgCTExtName;
 
     // Skip antispam test if user is member of special group
-    if ( $wgUser->isAllowed('cleantalk-bypass') ) {
+    if ( $user->isAllowed('cleantalk-bypass') ) {
         return;
     }
     $errors = [];
@@ -201,8 +203,8 @@ public static function onTitleMove( Title $title, Title $newtitle, User $user )
     $ctResult = CTBody::onSpamCheck(
         'check_message', array(
             'message' => $newtitle->mUrlform ,
-            'sender_email' => $wgUser->mEmail,
-            'sender_nickname' => $wgUser->mName,
+            'sender_email' => $user->mEmail,
+            'sender_nickname' => $user->mName,
         )
     );
     if ( $ctResult->errno != 0 ) {

--- a/Antispam/extension.json
+++ b/Antispam/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "Antispam by CleanTalk",
-	"version": "2.3",
+	"version": "2.4",
 	"author": "CleanTalk Developers Team",
 	"url": "https://www.mediawiki.org/wiki/Extension:Antispam",
 	"description": "cleantalk.org is a cloud antispam service ",


### PR DESCRIPTION
Hi! I recently discovered that by setting cookies on every page view, this extension effectively prevents CDNs like Cloudflare from doing their job. This is because when a cookie is set, MediaWiki thinks this may lead to a cookie leak and potentially a session hijack, so it sets a "private" flag in the cache-control header (see [here](https://doc.wikimedia.org/mediawiki-core/master/php/HeaderCallback_8php_source.html#l00035)) which prevents Cloudflare from caching any pages. This patch adds a check that prevents this extension from setting any cookies (and adding any JS) when a user is VIEWING a page (sorry that it got mixed up with my previous patch, I'm not too good at git and GitHub yet). I've done some monitoring of antispam activity for appropedia.org after the patch, and all seems to be working well, Cleantalk is working as always.